### PR TITLE
Release v1.3

### DIFF
--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -1223,6 +1223,105 @@
           }
         }
       }
+    },
+    "f7659287e97b490c7549166241abfe0a95364e777a8ee9db454c7958ae9bd1c9": {
+      "address": "0x94356DBed7e3523aCA0e3cB4fBd8dB0fE68bD66F",
+      "txHash": "0x3634ef30f73db58dd3b5d5a09139f97fca70b738ae8a661dfad2e8a1e5b1e8f2",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "value",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "Box",
+            "src": "contracts/Box.sol:9"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/addresses.json
+++ b/addresses.json
@@ -2,7 +2,7 @@
   "5": {
     "Box": {
       "address": "0x22431A9012cC3Fa9Ba7643e16275e8565Ff3a0BA",
-      "implementation": "0x02C0AE8e78843B8c5389b57077EBD26632206Fe0"
+      "implementation": "0x94356DBed7e3523aCA0e3cB4fBd8dB0fE68bD66F"
     },
     "Greeter": {
       "address": "0x2dE4b51615E2d732905131e90201ca362F1789Fb",

--- a/contracts/Box.sol
+++ b/contracts/Box.sol
@@ -25,7 +25,7 @@ contract Box is Initializable, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function version() external pure returns (string memory) {
-      return "v1.3.7";
+      return "v1.3.8";
     }
 
     function _authorizeUpgrade(address newImplementation)

--- a/releases/v1.3/deployed.json
+++ b/releases/v1.3/deployed.json
@@ -1,5 +1,5 @@
 {
   "Box": {
-    "implementation": "0x02C0AE8e78843B8c5389b57077EBD26632206Fe0"
+    "implementation": "0x94356DBed7e3523aCA0e3cB4fBd8dB0fE68bD66F"
   }
 }


### PR DESCRIPTION
Prepare release v1.3. This release deploys a new implementation for the upgradeable Box contract, and creates a gnosis safe proposal to request multisig signers to approve the upgrade. The code to be deployed was audited in a previous commit.

```yml
title: Upgrade to v1.3
network: goerli
deploy: prepare-upgrade Box
verify: verify-deployed
finish: propose-upgrade
audited: f37fb0c75b4ec2c13e063d257499e7dcc643e468
```